### PR TITLE
Add model v4 samples for async/await

### DIFF
--- a/js/src/functions/httpTriggerBadAsync.js
+++ b/js/src/functions/httpTriggerBadAsync.js
@@ -1,0 +1,21 @@
+// NOT RECOMMENDED PATTERN
+const { app } = require('@azure/functions');
+const fs = require('fs');
+
+app.http('httpTriggerBadAsync', {
+    methods: ['GET', 'POST'],
+    authLevel: 'anonymous',
+    handler: async (request, context) => {
+        let fileData;
+        fs.readFile('./helloWorld.txt', (err, data) => {
+            if (err) {
+                context.error(err);
+                // BUG #1: This will result in an uncaught exception that crashes the entire process
+                throw err;
+            }
+            fileData = data;
+        });
+        // BUG #2: fileData is not guaranteed to be set before the invocation ends
+        return { body: fileData };
+    },
+});

--- a/js/src/functions/httpTriggerBadAsync.js
+++ b/js/src/functions/httpTriggerBadAsync.js
@@ -1,4 +1,4 @@
-// NOT RECOMMENDED PATTERN
+// DO NOT USE THIS CODE
 const { app } = require('@azure/functions');
 const fs = require('fs');
 

--- a/js/src/functions/httpTriggerGoodAsync.js
+++ b/js/src/functions/httpTriggerGoodAsync.js
@@ -1,0 +1,18 @@
+// Recommended pattern
+const { app } = require('@azure/functions');
+const fs = require('fs/promises');
+
+app.http('httpTriggerGoodAsync', {
+    methods: ['GET', 'POST'],
+    authLevel: 'anonymous',
+    handler: async (request, context) => {
+        try {
+            const fileData = await fs.readFile('./helloWorld.txt');
+            return { body: fileData };
+        } catch (err) {
+            context.error(err);
+            // This rethrown exception will only fail the individual invocation, instead of crashing the whole process
+            throw err;
+        }
+    },
+});

--- a/ts/src/functions/httpTriggerBadAsync.ts
+++ b/ts/src/functions/httpTriggerBadAsync.ts
@@ -1,4 +1,4 @@
-// NOT RECOMMENDED PATTERN
+// DO NOT USE THIS CODE
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 import * as fs from 'fs';
 

--- a/ts/src/functions/httpTriggerBadAsync.ts
+++ b/ts/src/functions/httpTriggerBadAsync.ts
@@ -1,0 +1,23 @@
+// NOT RECOMMENDED PATTERN
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import * as fs from 'fs';
+
+export async function httpTriggerBadAsync(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
+    let fileData: Buffer;
+    fs.readFile('./helloWorld.txt', (err, data) => {
+        if (err) {
+            context.error(err);
+            // BUG #1: This will result in an uncaught exception that crashes the entire process
+            throw err;
+        }
+        fileData = data;
+    });
+    // BUG #2: fileData is not guaranteed to be set before the invocation ends
+    return { body: fileData };
+}
+
+app.http('httpTriggerBadAsync', {
+    methods: ['GET', 'POST'],
+    authLevel: 'anonymous',
+    handler: httpTriggerBadAsync,
+});

--- a/ts/src/functions/httpTriggerGoodAsync.ts
+++ b/ts/src/functions/httpTriggerGoodAsync.ts
@@ -1,0 +1,23 @@
+// Recommended pattern
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import * as fs from 'fs/promises';
+
+export async function httpTriggerGoodAsync(
+    request: HttpRequest,
+    context: InvocationContext
+): Promise<HttpResponseInit> {
+    try {
+        const fileData = await fs.readFile('./helloWorld.txt');
+        return { body: fileData };
+    } catch (err) {
+        context.error(err);
+        // This rethrown exception will only fail the individual invocation, instead of crashing the whole process
+        throw err;
+    }
+}
+
+app.http('httpTriggerGoodAsync', {
+    methods: ['GET', 'POST'],
+    authLevel: 'anonymous',
+    handler: httpTriggerGoodAsync,
+});


### PR DESCRIPTION
These are the model v4 samples to match the existing model v3 samples here: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v3#use-async-and-await

Related to https://github.com/Azure/azure-functions-nodejs-library/issues/184