### PR TITLE
Add warmup trigger samples for v4

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -8,7 +8,7 @@
       "name": "triggerdocs",
       "version": "1.0.0",
       "dependencies": {
-        "@azure/functions": "^4.0.0-alpha.13"
+        "@azure/functions": "^4.1.0"
       },
       "devDependencies": {
         "eslint": "^7.32.0",
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@azure/functions": {
-      "version": "4.0.0-alpha.13",
-      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.0-alpha.13.tgz",
-      "integrity": "sha512-zSxBgnTt+sGsF8f38XX8PyiRZ+Inr9PjOSfStyn48ppGyel1bp45AyRvR91DisCvkdnOjCLFcRydsbfikkXWaA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.1.0.tgz",
+      "integrity": "sha512-45WDaJZiTmvaIOPSdWWKL5NgzgUWsNzXDNlF7oCMLS43lE602qG7XE6Hdg9ewPWBj55URHRU7UWTHk4uDVqBGg==",
       "dependencies": {
         "long": "^4.0.0",
         "undici": "^5.13.0"

--- a/js/package.json
+++ b/js/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"No tests yet...\""
   },
   "dependencies": {
-    "@azure/functions": "^4.0.0-alpha.13"
+    "@azure/functions": "^4.1.0"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/js/src/functions/warmupTrigger1.js
+++ b/js/src/functions/warmupTrigger1.js
@@ -1,0 +1,7 @@
+const { app } = require('@azure/functions');
+
+app.warmup('warmupTrigger1', {
+    handler: (warmupContext, context) => {
+        context.log('Function App instance is warm.');
+    },
+});

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -8,7 +8,7 @@
       "name": "triggerdocsts",
       "version": "1.0.0",
       "dependencies": {
-        "@azure/functions": "^4.0.0-alpha.13"
+        "@azure/functions": "^4.1.0"
       },
       "devDependencies": {
         "@types/node": "^18.x",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@azure/functions": {
-      "version": "4.0.0-alpha.13",
-      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.0-alpha.13.tgz",
-      "integrity": "sha512-zSxBgnTt+sGsF8f38XX8PyiRZ+Inr9PjOSfStyn48ppGyel1bp45AyRvR91DisCvkdnOjCLFcRydsbfikkXWaA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.1.0.tgz",
+      "integrity": "sha512-45WDaJZiTmvaIOPSdWWKL5NgzgUWsNzXDNlF7oCMLS43lE602qG7XE6Hdg9ewPWBj55URHRU7UWTHk4uDVqBGg==",
       "dependencies": {
         "long": "^4.0.0",
         "undici": "^5.13.0"

--- a/ts/package.json
+++ b/ts/package.json
@@ -12,7 +12,7 @@
     "test": "echo \"No tests yet...\""
   },
   "dependencies": {
-    "@azure/functions": "^4.0.0-alpha.13"
+    "@azure/functions": "^4.1.0"
   },
   "devDependencies": {
     "@types/node": "^18.x",

--- a/ts/src/functions/warmupTrigger1.ts
+++ b/ts/src/functions/warmupTrigger1.ts
@@ -1,6 +1,6 @@
-import { app, InvocationContext, WarmupContextOptions } from "@azure/functions";
+import { app, InvocationContext, WarmupContext } from "@azure/functions";
 
-export async function warmupFunction(warmupContext: WarmupContextOptions, context: InvocationContext): Promise<void> {
+export async function warmupFunction(warmupContext: WarmupContext, context: InvocationContext): Promise<void> {
     context.log('Function App instance is warm.');
 }
 

--- a/ts/src/functions/warmupTrigger1.ts
+++ b/ts/src/functions/warmupTrigger1.ts
@@ -1,0 +1,9 @@
+import { app, InvocationContext, WarmupContextOptions } from "@azure/functions";
+
+export async function warmupFunction(warmupContext: WarmupContextOptions, context: InvocationContext): Promise<void> {
+    context.log('Function App instance is warm.');
+}
+
+app.warmup('warmup', {
+    handler: warmupFunction,
+});


### PR DESCRIPTION
This PR is a follow-up to [Updating docs for EventGrid output bindings and warmup triggers](https://github.com/MicrosoftDocs/azure-docs-pr/pull/257704).

Here I am taking the code samples introduced in [functions-bindings-warmup.md](https://github.com/MicrosoftDocs/azure-docs-pr/pull/257704/files#diff-701081a210149b6c493629a74a115d80262559a4b995157eaf10e984cd2f1160) and moving them to this repo.

I will then open a new PR in the `azure-docs-pr` to link to these samples using the `:::code language="javascript" source="~/path/to/file" :::` syntax.