### PR TITLE
Add http stream samples

### DIFF
--- a/js/src/functions/httpTriggerStreamRequest.js
+++ b/js/src/functions/httpTriggerStreamRequest.js
@@ -1,0 +1,14 @@
+const { app } = require('@azure/functions');
+const { createWriteStream } = require('fs');
+const { Writable } = require('stream');
+
+app.http('httpTriggerStreamRequest', {
+    methods: ['POST'],
+    authLevel: 'anonymous',
+    handler: async (request, context) => {
+        const writeStream = createWriteStream('<output file path>');
+        await request.body.pipeTo(Writable.toWeb(writeStream));
+
+        return { body: 'Done!' };
+    },
+});

--- a/js/src/functions/httpTriggerStreamResponse.js
+++ b/js/src/functions/httpTriggerStreamResponse.js
@@ -1,0 +1,12 @@
+const { app } = require('@azure/functions');
+const { createReadStream } = require('fs');
+
+app.http('httpTriggerStreamResponse', {
+    methods: ['GET'],
+    authLevel: 'anonymous',
+    handler: async (request, context) => {
+        const body = createReadStream('<input file path>');
+
+        return { body };
+    },
+});

--- a/ts/src/functions/httpTriggerStreamRequest.ts
+++ b/ts/src/functions/httpTriggerStreamRequest.ts
@@ -1,0 +1,19 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import { createWriteStream } from 'fs';
+import { Writable } from 'stream';
+
+export async function httpTriggerStreamRequest(
+    request: HttpRequest,
+    context: InvocationContext
+): Promise<HttpResponseInit> {
+    const writeStream = createWriteStream('<output file path>');
+    await request.body.pipeTo(Writable.toWeb(writeStream));
+
+    return { body: 'Done!' };
+}
+
+app.http('httpTriggerStreamRequest', {
+    methods: ['POST'],
+    authLevel: 'anonymous',
+    handler: httpTriggerStreamRequest,
+});

--- a/ts/src/functions/httpTriggerStreamResponse.ts
+++ b/ts/src/functions/httpTriggerStreamResponse.ts
@@ -1,0 +1,17 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import { createReadStream } from 'fs';
+
+export async function httpTriggerStreamResponse(
+    request: HttpRequest,
+    context: InvocationContext
+): Promise<HttpResponseInit> {
+    const body = createReadStream('<input file path>');
+
+    return { body };
+}
+
+app.http('httpTriggerStreamResponse', {
+    methods: ['GET'],
+    authLevel: 'anonymous',
+    handler: httpTriggerStreamResponse,
+});


### PR DESCRIPTION
I wanted to keep these simple and direct users to my sample app for a more fully-fledged working example:
https://github.com/ejizba/azure-functions-nodejs-stream