### PR TITLE
Fix TypeScript queue trigger sample to use string type instead of unknown

### DIFF
--- a/ts/src/functions/storageQueueTrigger1.ts
+++ b/ts/src/functions/storageQueueTrigger1.ts
@@ -1,6 +1,6 @@
 import { app, InvocationContext } from '@azure/functions';
 
-export async function storageQueueTrigger1(queueItem: unknown, context: InvocationContext): Promise<void> {
+export async function storageQueueTrigger1(queueItem: string, context: InvocationContext): Promise<void> {
     context.log('Storage queue function processed work item:', queueItem);
     context.log('expirationTime =', context.triggerMetadata.expirationTime);
     context.log('insertionTime =', context.triggerMetadata.insertionTime);
@@ -10,7 +10,7 @@ export async function storageQueueTrigger1(queueItem: unknown, context: Invocati
     context.log('dequeueCount =', context.triggerMetadata.dequeueCount);
 }
 
-app.storageQueue('storageQueueTrigger1', {
+app.storageQueue<string>('storageQueueTrigger1', {
     queueName: 'myqueue-items',
     connection: 'MyStorageConnectionAppSetting',
     handler: storageQueueTrigger1,


### PR DESCRIPTION
Uses the generic type parameter `app.storageQueue<string>(...)` added in `@azure/functions` v4.11.0 to type the queue trigger handler parameter as `string` instead of `unknown`. This fixes a usability issue for TypeScript users who can't directly use the `queueItem` parameter without type narrowing.

### Changes
- `storageQueueTrigger1.ts`: Changed handler parameter from `unknown` to `string` and added `<string>` generic to `app.storageQueue()` call.